### PR TITLE
fix circleci and travis starting

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ jobs:
       CIRCLE_TEST_REPORTS: /tmp/circleci-test-results
     docker:
     - image: circleci/build-image:ubuntu-14.04-XXL-upstart-1189-5614f37
-      command: /sbin/init
+      run: sudo service postgresql start
     steps:
     # Machine Setup
     - checkout

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: java
+dist: trust
 jdk:
   - oraclejdk8
 install: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,8 @@ jdk:
   - oraclejdk8
 install: true
 script:
+  - git config --global user.email "circle@circleci.com"
+  - git config --global user.name "CircleCI"
   - chmod +x ./scripts/inst.sh
   - ./scripts/inst.sh --setup --remote
 after_success:


### PR DESCRIPTION
command: /sbin/init doesnt work anymore on newest circleci 

for travis latest distro that use cant install openjdk8 so you use ubuntu 14.04 (codename: trust)