### PR TITLE
Workaround to Make Project Build

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -209,6 +209,10 @@
             <url>https://hub.spigotmc.org/nexus/content/groups/public/</url>
         </repository>
         <!-- Akarin -->
+		<repository>
+			<id>papermc</id>
+			<url>https://papermc.io/repo/repository/maven-public/</url>
+		</repository>
         <repository>
             <id>piratescode</id>
             <url>https://nexus.piratescode.co.uk/</url>

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -37,9 +37,7 @@ echo "[Akarin] Ready to build"
 		\cp -rf "$basedir/pom.xml" "$paperbasedir/Paper-Server/"
 		mvn clean install -Dmaven.test.skip=true
 	else
-		rm -rf Paper-API/src
-		rm -rf Paper-Server/src
-		./paper patch
+		echo "[Akarin] Test and repatch has been skipped"
 		\cp -rf "$basedir/api/src/main" "$paperbasedir/Paper-API/src/"
 		\cp -rf "$basedir/api/pom.xml" "$paperbasedir/Paper-API/"
 		\cp -rf "$basedir/src" "$paperbasedir/Paper-Server/"


### PR DESCRIPTION
Quick and Dirty hacks to get Akarin to build on the build server, will reimplement tests later.